### PR TITLE
Support for verifying catalog signed files on windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,15 @@ sha-1 = "0.9.4"
 core-foundation = "0.9"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = [ "std",
-                                         "handleapi",
-                                         "processenv",
-                                         "processthreadsapi",
-                                         "softpub",
-                                         "tlhelp32",
-                                         "winbase",
-                                         "winerror",
-                                         "winnt",
-                                         "wincrypt",
-                                         "wintrust",
-                                         "impl-default" ] }
+windows-sys = { version = "0.48.0", features = [
+                                        "Win32_Foundation",
+                                        "Win32_Storage_FileSystem",
+                                        "Win32_System_Threading",
+                                        "Win32_Security",
+                                        "Win32_Security_WinTrust",
+                                        "Win32_Security_Cryptography",
+                                        "Win32_Security_Cryptography_Catalog"
+                                    ] }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub struct SignatureContext(Context);
 ///
 /// `country`: OID 2.5.4.6
 ///
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Name {
     pub common_name: Option<String>,       // 2.5.4.3
     pub organization: Option<String>,      // 2.5.4.10
@@ -168,12 +168,12 @@ mod tests {
 
         assert_eq!(
             ctx.sha1_thumbprint(),
-            "a4341b9fd50fb9964283220a36a1ef6f6faa7840"
+            "58fd671e2d4d200ce92d6e799ec70df96e6d2664"
         );
 
         assert_eq!(
             ctx.serial().as_deref(),
-            Some("3300000266bd1580efa75cd6d3000000000266")
+            Some("330000041331bc198807a90774000000000413")
         );
     }
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -8,6 +8,38 @@ use wintrust_sys::*;
 pub(crate) struct Verifier(Vec<u16>);
 pub(crate) use context::Context;
 
+struct CleanupContext {
+    h_file: HANDLE,
+    h_cat_admin: HANDLE,
+    h_cat_info: HANDLE,
+}
+
+impl CleanupContext {
+    pub fn new(h_file: HANDLE) -> Self {
+        CleanupContext {
+            h_file,
+            h_cat_admin: 0,
+            h_cat_info: 0,
+        }
+    }
+}
+
+impl Drop for CleanupContext {
+    fn drop(&mut self) {
+        if self.h_file != 0 {
+            unsafe { CloseHandle(self.h_file) };
+        }
+
+        if self.h_cat_info != 0 {
+            unsafe { CryptCATAdminReleaseCatalogContext(self.h_cat_admin, self.h_cat_info, 0) };
+        }
+
+        if self.h_cat_admin != 0 {
+            unsafe { CryptCATAdminReleaseContext(self.h_cat_admin, 0) };
+        }
+    }
+}
+
 impl Verifier {
     pub fn for_file<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
         use std::os::windows::ffi::OsStrExt;
@@ -20,57 +52,156 @@ impl Verifier {
 
     // Extract the path of a pid, then call for file
     pub fn for_pid(pid: i32) -> Result<Self, Error> {
-        let path = get_process_path(pid as _).map_err(|e| Error::IoError(e))?;
+        let path = get_process_path(pid as _)?;
         Self::for_file(path)
     }
 
     pub fn verify(&self) -> Result<Context, Error> {
-        let mut file_info = WINTRUST_FILE_INFO {
-            cbStruct: std::mem::size_of::<WINTRUST_FILE_INFO>() as _,
-            pcwszFilePath: self.0.as_ptr(),
-            hFile: std::ptr::null_mut(),
-            pgKnownSubject: std::ptr::null(),
-        };
+        unsafe {
+            let mut file_info: WINTRUST_FILE_INFO = std::mem::zeroed();
+            file_info.cbStruct = std::mem::size_of::<WINTRUST_FILE_INFO>() as u32;
+            file_info.pcwszFilePath = self.0.as_ptr();
 
-        let mut data = WINTRUST_DATA {
-            cbStruct: std::mem::size_of::<WINTRUST_DATA>() as _,
-            pPolicyCallbackData: std::ptr::null_mut(),
-            pSIPClientData: std::ptr::null_mut(),
-            dwUIChoice: WTD_UI_NONE,
-            fdwRevocationChecks: WTD_REVOKE_NONE,
-            dwUnionChoice: WTD_CHOICE_FILE,
-            u: Default::default(),
-            dwStateAction: WTD_STATEACTION_VERIFY,
-            hWVTStateData: std::ptr::null_mut(),
-            pwszURLReference: std::ptr::null_mut(),
-            dwProvFlags: WTD_DISABLE_MD2_MD4
-                | WTD_REVOCATION_CHECK_END_CERT
-                | WTD_NO_IE4_CHAIN_FLAG,
-            dwUIContext: WTD_UICONTEXT_EXECUTE,
-            pSignatureSettings: std::ptr::null_mut(),
-        };
+            match self.verify_internal(Some(&mut file_info), None) {
+                Ok(context) => Ok(context),
+                Err(err) => {
+                    if err == TRUST_E_NOSIGNATURE as u32 {
+                        self.verify_catalog_signed()
+                    } else {
+                        Err(Error::OsError(err as i32))
+                    }
+                }
+            }
+        }
+    }
 
-        *unsafe { data.u.pFile_mut() } = &mut file_info;
+    unsafe fn verify_catalog_signed(&self) -> Result<Context, Error> {
+        let h_file = CreateFileW(
+            self.0.as_ptr(),
+            GENERIC_READ,
+            FILE_SHARE_READ,
+            std::ptr::null_mut(),
+            OPEN_EXISTING,
+            0,
+            0,
+        );
+
+        if h_file == INVALID_HANDLE_VALUE {
+            let err = GetLastError() as i32;
+            return Err(Error::OsError(err));
+        }
+
+        let mut ctx = CleanupContext::new(h_file);
+
+        let mut h_cat_admin: HANDLE = 0;
+        let result = CryptCATAdminAcquireContext2(
+            &mut h_cat_admin,
+            std::ptr::null(),
+            BCRYPT_SHA256_ALGORITHM,
+            std::ptr::null(),
+            0,
+        );
+        if result == 0 {
+            let err = GetLastError() as i32;
+            return Err(Error::OsError(err));
+        }
+
+        ctx.h_cat_admin = h_cat_admin;
+
+        let mut hash_size: DWORD = 32;
+        let mut hash_buffer: Vec<BYTE> = vec![0; hash_size as usize];
+        let result = CryptCATAdminCalcHashFromFileHandle2(
+            h_cat_admin,
+            h_file,
+            &mut hash_size,
+            hash_buffer.as_mut_ptr(),
+            0,
+        );
+        if result == 0 {
+            let err = GetLastError() as i32;
+            return Err(Error::OsError(err));
+        }
+
+        let h_cat_info = CryptCATAdminEnumCatalogFromHash(
+            h_cat_admin,
+            hash_buffer.as_ptr(),
+            hash_size,
+            0,
+            std::ptr::null_mut(),
+        );
+        if h_cat_info == 0 {
+            return Err(Error::Unsigned);
+        }
+
+        ctx.h_cat_info = h_cat_info;
+
+        let mut ci: CATALOG_INFO = std::mem::zeroed();
+        ci.cbStruct = std::mem::size_of::<CATALOG_INFO>() as u32;
+
+        let result = CryptCATCatalogInfoFromContext(h_cat_info, &mut ci, 0);
+        if result == 0 {
+            let err = GetLastError() as i32;
+            return Err(Error::OsError(err));
+        }
+
+        let hash_str = hash_buffer
+            .iter()
+            .map(|&val| format!("{:02x}", val))
+            .collect::<Vec<String>>()
+            .join("");
+        let mut hash: Vec<u16> = hash_str.encode_utf16().collect();
+        hash.push(0); // Make sure hash is null terminated
+
+        let mut wci: WINTRUST_CATALOG_INFO = std::mem::zeroed();
+        wci.cbStruct = std::mem::size_of::<WINTRUST_CATALOG_INFO>() as u32;
+        wci.pcwszCatalogFilePath = ci.wszCatalogFile.as_ptr();
+        wci.pcwszMemberFilePath = self.0.as_ptr();
+        wci.pcwszMemberTag = hash.as_ptr();
+
+        match self.verify_internal(None, Some(&mut wci)) {
+            Ok(context) => Ok(context),
+            Err(err) => Err(Error::OsError(err as i32)),
+        }
+    }
+
+    unsafe fn verify_internal(
+        &self,
+        file_info: Option<*mut WINTRUST_FILE_INFO>,
+        catalog_info: Option<*mut WINTRUST_CATALOG_INFO>,
+    ) -> Result<Context, WIN32_ERROR> {
+        // Initialize the WINTRUST_DATA structure
+        let mut data: WINTRUST_DATA = std::mem::zeroed();
+        data.cbStruct = std::mem::size_of::<WINTRUST_DATA>() as u32;
+        data.dwUIChoice = WTD_UI_NONE;
+        data.fdwRevocationChecks = WTD_REVOKE_NONE;
+        data.dwStateAction = WTD_STATEACTION_VERIFY;
+        data.dwUIContext = WTD_UICONTEXT_EXECUTE;
+
+        if let Some(fi) = file_info {
+            data.dwUnionChoice = WTD_CHOICE_FILE;
+            data.Anonymous.pFile = fi;
+            data.dwProvFlags =
+                WTD_DISABLE_MD2_MD4 | WTD_REVOCATION_CHECK_END_CERT | WTD_NO_IE4_CHAIN_FLAG;
+        } else if let Some(ci) = catalog_info {
+            data.dwUnionChoice = WTD_CHOICE_CATALOG;
+            data.Anonymous.pCatalog = ci;
+            data.dwProvFlags = WTD_CACHE_ONLY_URL_RETRIEVAL | WTD_USE_DEFAULT_OSVER_CHECK;
+        } else {
+            return Err(ERROR_INVALID_PARAMETER);
+        }
 
         let mut guid = WINTRUST_ACTION_GENERIC_VERIFY_V2;
 
         // Verify that the signature is actually valid
-        match unsafe {
-            WinVerifyTrust(
-                INVALID_HANDLE_VALUE as _,
-                &mut guid,
-                &mut data as *mut _ as _,
-            )
-        } {
+        match WinVerifyTrust(
+            INVALID_HANDLE_VALUE as _,
+            &mut guid,
+            &mut data as *mut _ as _,
+        ) {
             0 => {}
             _ => {
                 let _ = Context::new(data.hWVTStateData); // So close gets called on the data
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() == Some(winapi::shared::winerror::TRUST_E_NOSIGNATURE) {
-                    return Err(Error::Unsigned);
-                } else {
-                    return Err(Error::IoError(err));
-                }
+                return Err(GetLastError());
             }
         }
 
@@ -79,27 +210,58 @@ impl Verifier {
 }
 
 /// Attempts to get the full system path for a given proccess id
-fn get_process_path(proc_id: u32) -> std::io::Result<String> {
-    use winapi::shared::minwindef;
-    use winapi::um::{processthreadsapi, winbase, winnt};
-
+fn get_process_path(proc_id: u32) -> Result<String, Error> {
     let mut buf = [0u16; 2048];
 
     unsafe {
-        let proc_handle = match processthreadsapi::OpenProcess(
-            winnt::PROCESS_QUERY_LIMITED_INFORMATION,
-            minwindef::FALSE,
-            proc_id,
-        ) {
-            handle if handle.is_null() => return Err(std::io::Error::last_os_error()),
+        let proc_handle = match OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, proc_id) {
+            handle if handle == 0 => return Err(Error::OsError(GetLastError() as i32)),
             handle => handle,
         };
 
         let mut path_len = buf.len() as _;
 
-        match winbase::QueryFullProcessImageNameW(proc_handle, 0, buf.as_mut_ptr(), &mut path_len) {
-            0 => Err(std::io::Error::last_os_error()),
+        match QueryFullProcessImageNameW(proc_handle, 0, buf.as_mut_ptr(), &mut path_len) {
+            0 => Err(Error::OsError(GetLastError() as i32)),
             _ => Ok(String::from_utf16_lossy(&buf[..path_len as usize])),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // This imports all the items from the parent module.
+    use super::*;
+    extern crate std;
+
+    fn verify_file(process_path: &str, expected_issuer: &str) {
+        match Verifier::for_file(process_path) {
+            Ok(signature_verifier) => {
+                match signature_verifier.verify() {
+                    Ok(context) => {
+                        assert_eq!(context.issuer_name().organization.unwrap(), expected_issuer);
+                    }
+                    Err(err) => {
+                        panic!("failed to verify signature. {:?}", err);
+                    }
+                };
+            }
+            Err(err) => {
+                panic!("failed to get signature verifier. {:?}", err);
+            }
+        };
+    }
+
+    #[test]
+    fn test_embeded_signed_file() {
+        verify_file(
+            "c:\\windows\\system32\\svchost.exe",
+            "Microsoft Corporation",
+        );
+    }
+
+    #[test]
+    fn test_catalog_signed_file() {
+        verify_file("c:\\windows\\system32\\cmd.exe", "Microsoft Corporation");
     }
 }

--- a/src/windows/wintrust_sys.rs
+++ b/src/windows/wintrust_sys.rs
@@ -1,9 +1,24 @@
-pub use winapi::shared::minwindef::{BOOL, DWORD};
-pub use winapi::shared::ntdef::HANDLE;
-pub use winapi::um::handleapi::INVALID_HANDLE_VALUE;
-pub use winapi::um::softpub::WINTRUST_ACTION_GENERIC_VERIFY_V2;
-pub use winapi::um::wincrypt::*;
-pub use winapi::um::wintrust::*;
+use std::ffi::{c_int, c_uchar, c_ulong};
+
+pub use windows_sys::Win32::Foundation::{
+    CloseHandle, GetLastError, ERROR_INVALID_PARAMETER, FALSE, GENERIC_READ, HANDLE,
+    INVALID_HANDLE_VALUE, TRUST_E_NOSIGNATURE, TRUST_E_NO_SIGNER_CERT, WIN32_ERROR,
+};
+pub use windows_sys::Win32::Security::Cryptography::Catalog::*;
+pub use windows_sys::Win32::Security::Cryptography::*;
+pub use windows_sys::Win32::Security::WinTrust::*;
+pub use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, OPEN_EXISTING,
+};
+pub use windows_sys::Win32::System::Threading::{
+    OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION,
+};
+
+#[allow(non_camel_case_types)]
+pub type PCCERT_CONTEXT = *const CERT_CONTEXT;
+pub type DWORD = c_ulong;
+pub type BOOL = c_int;
+pub type BYTE = c_uchar;
 
 #[link(name = "Wintrust")]
 extern "system" {


### PR DESCRIPTION
On windows many operating system binaries are catalog signed, i.e. the signature information for those binaries resides in the windows catalog database instead of being embedded in the binaries itself. To be able to to verify signature for such files need to find the catalog file containing that information (based on PE file hash) and then pass it to WinVerifyTrust to validate the signature information.

Had to change from using winapi crate to windows_sys crate because some of the windows apis were not available in winapi crate.