### PR TITLE
Update wintrust_sys.rs

### DIFF
--- a/src/windows/wintrust_sys.rs
+++ b/src/windows/wintrust_sys.rs
@@ -5,7 +5,6 @@ pub use winapi::um::softpub::WINTRUST_ACTION_GENERIC_VERIFY_V2;
 pub use winapi::um::wincrypt::*;
 pub use winapi::um::wintrust::*;
 
-#[link(name = "Wintrust")]
 extern "system" {
     pub fn WTHelperProvDataFromStateData(handle: HANDLE) -> *const std::ffi::c_void;
 


### PR DESCRIPTION
Fix linker error looking for Wintrust.dll when compiling on Linux.

I am using codesign-verify to validate the authenticode signature on Windows executables.  When I cross compile on Mac for Windows, it works fine; when I cross compile on Linux for Windows, it fails with a linker error:

```
note: /usr/bin/x86_64-w64-mingw32-ld: cannot find -lWintrust
```

A simple test case follows:

Cargo.toml:

```
[package]
name = "test"
version = "0.1.0"
edition = "2018"

[dependencies]
codesign-verify = "0.1.2"
```

main.rs:
```
extern crate codesign_verify;

use codesign_verify::CodeSignVerifier;

fn main() {
	let path = "C:/Windows/explorer.exe";
	CodeSignVerifier::for_file(path).unwrap().verify().unwrap();
	println!("Success");
}
```

On the build system (Linux) I have installed Rust, added the x86_64-pc-windows-gnu target, and installed mingw-w64.
```
rustup target add x86_64-pc-windows-gnu
sudo apt-get install mingw-w64
```

I build with command:

```
cargo build --target=x86_64-pc-windows-gnu
```

From my testing, it looks like the

```
#[link(name = "Wintrust")]
```

directive in wintrust_sys.rs is causing this.  I am new to rust, and not sure why it does not cause this same problem when cross compiling on Mac, but from my testing by deleting this I can successfully compile on both Mac and Linux, and the resulting binary works in Windows.

I would appreciate any corrections / suggestions on my fix here.

Cheers